### PR TITLE
Add authN token refresh

### DIFF
--- a/server/core/ciam/httphandler.go
+++ b/server/core/ciam/httphandler.go
@@ -139,8 +139,8 @@ func (c client) validateRequestsQuotaUsage(w http.ResponseWriter, r *http.Reques
 	}
 
 	if quotasUsage.RateDay.Used >= quotasUsage.RateDay.Limit {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"error":"quota exceeded"}`))
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"daily quota exceeded"}`))
 		c.logger.Printf("quota exceeded for user %s", user.ID)
 		return false
 	}

--- a/server/core/ciam/iam_test.go
+++ b/server/core/ciam/iam_test.go
@@ -283,8 +283,8 @@ func Test_client_validateRequestsQuotaUsage(t *testing.T) {
 				user:   &User{},
 				writer: &utils.MockWriter{},
 			},
-			wantStatuCode: http.StatusForbidden,
-			wantBody:      []byte(`{"error":"quota exceeded"}`),
+			wantStatuCode: http.StatusTooManyRequests,
+			wantBody:      []byte(`{"error":"daily quota exceeded"}`),
 			want:          false,
 		},
 		{

--- a/webclient/src/ciam.ts
+++ b/webclient/src/ciam.ts
@@ -371,7 +371,7 @@ function u(...typs: any[]) {
     return {unionMembers: typs};
 }
 
-function init(props: any[], additional: any) {
+function o(props: any[], additional: any) {
     return {props, additional};
 }
 
@@ -379,30 +379,30 @@ function r(name: string) {
     return {ref: name};
 }
 
-const typeMapClaimsStd = init([
+const typeMapClaimsStd = o([
     {json: "sub", js: "sub", typ: ""},
     {json: "exp", js: "exp", typ: 0},
 ], null);
 
 const typeMap: any = {
-    "tokens_raw": init([
+    "tokens_raw": o([
         {json: "id", js: "id", typ: ""},
         {json: "access", js: "access", typ: u(undefined, "")},
         {json: "refresh", js: "refresh", typ: u(undefined, "")},
     ], null),
-    "user_quotas": init([
+    "user_quotas": o([
         {json: "prompt_length_max", js: "prompt_length_max", typ: 0},
         {json: "rpm", js: "rpm", typ: 0},
         {json: "rpd", js: "rpd", typ: 0},
     ], null),
     typeMapClaimsStd,
     "claimsRefresh": typeMapClaimsStd,
-    "claimsID": init([
+    "claimsID": o([
         {json: "email", js: "email", typ: u(undefined, "")},
         {json: "fingerprint", js: "fingerprint", typ: u(undefined, "")},
         ...typeMapClaimsStd.props,
     ], null),
-    "claimsAccess": init([
+    "claimsAccess": o([
         {json: "role", js: "role", typ: 0},
         {json: "quotas", js: "quotas", typ: r("user_quotas")},
         ...typeMapClaimsStd.props,


### PR DESCRIPTION
## What changed

### Client
- Added token refresh logic in the client
- Fixed authN when triggering generation using keyboard's key combination (ctr+enter)

### Server
- Adjusted response status code and error msg

## Why do we need it

- UX improvement
